### PR TITLE
[AI-225] Replace enum with strum for chain scheme etc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +113,8 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "thiserror",
  "toml",
 ]
@@ -251,6 +259,24 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ serde_json = "1.0"
 toml = "0.8"
 thiserror = "2.0"
 chrono = "0.4"
+strum = "0.27"
+strum_macros = "0.27"
+
 
 [build-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,23 +4,58 @@ use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
+use strum_macros::{Display, EnumString};
 
-/// Chain types for immunoglobulins and T-cell receptors
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, EnumString, Display, PartialEq, Serialize, Deserialize, Clone, Copy)]
 pub enum Chain {
-    /// Immunoglobulin Heavy chain
+    #[strum(
+        serialize = "IGH",
+        serialize = "H",
+        serialize = "heavy",
+        ascii_case_insensitive
+    )]
     IGH,
-    /// Immunoglobulin Kappa light chain
+    #[strum(
+        serialize = "IGK",
+        serialize = "K",
+        serialize = "kappa",
+        ascii_case_insensitive
+    )]
     IGK,
-    /// Immunoglobulin Lambda light chain
+    #[strum(
+        serialize = "IGL",
+        serialize = "L",
+        serialize = "lambda",
+        ascii_case_insensitive
+    )]
     IGL,
-    /// T-cell receptor Alpha chain
+    #[strum(
+        serialize = "TRA",
+        serialize = "A",
+        serialize = "alpha",
+        ascii_case_insensitive
+    )]
     TRA,
-    /// T-cell receptor Beta chain
+    #[strum(
+        serialize = "TRB",
+        serialize = "B",
+        serialize = "beta",
+        ascii_case_insensitive
+    )]
     TRB,
-    /// T-cell receptor Gamma chain
+    #[strum(
+        serialize = "TRG",
+        serialize = "G",
+        serialize = "gamma",
+        ascii_case_insensitive
+    )]
     TRG,
-    /// T-cell receptor Delta chain
+    #[strum(
+        serialize = "TRD",
+        serialize = "D",
+        serialize = "delta",
+        ascii_case_insensitive
+    )]
     TRD,
 }
 
@@ -36,54 +71,15 @@ impl Chain {
     }
 }
 
-impl fmt::Display for Chain {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-impl FromStr for Chain {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        match s.to_uppercase().as_str() {
-            "IGH" | "H" => Ok(Chain::IGH),
-            "IGK" | "K" => Ok(Chain::IGK),
-            "IGL" | "L" => Ok(Chain::IGL),
-            "TRA" | "A" => Ok(Chain::TRA),
-            "TRB" | "B" => Ok(Chain::TRB),
-            "TRG" | "G" => Ok(Chain::TRG),
-            "TRD" | "D" => Ok(Chain::TRD),
-            _ => Err(Error::InvalidChain(s.to_string())),
-        }
-    }
-}
-
 /// Numbering schemes for output
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, EnumString, Display, PartialEq, Serialize, Deserialize, Clone, Copy)]
 pub enum Scheme {
     /// IMGT numbering (canonical internal representation)
+    #[strum(serialize = "IMGT", ascii_case_insensitive)]
     IMGT,
     /// Kabat numbering (derived from IMGT)
+    #[strum(serialize = "Kabat", ascii_case_insensitive)]
     Kabat,
-}
-
-impl fmt::Display for Scheme {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-impl FromStr for Scheme {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        match s.to_uppercase().as_str() {
-            "IMGT" => Ok(Scheme::IMGT),
-            "KABAT" => Ok(Scheme::Kabat),
-            _ => Err(Error::InvalidScheme(s.to_string())),
-        }
-    }
 }
 
 /// Position in a numbered sequence


### PR DESCRIPTION
This PR replaces manual from/to string impls for Chain and Scheme with `strum` crate, also adding case-insensitive aliases for their initialization, e.g.:

```rust
#[derive(Debug, EnumString, Display, PartialEq, Serialize, Deserialize, Clone, Copy)]
pub enum Chain {
    #[strum(
        serialize = "IGH",
        serialize = "H",
        serialize = "heavy",
        ascii_case_insensitive
    )]
    IGH,
    #[strum(
        serialize = "IGK",
        serialize = "K",
        serialize = "kappa",
        ascii_case_insensitive
    )]
    IGK,
    #[strum(
        serialize = "IGL",
        serialize = "L",
        serialize = "lambda",
        ascii_case_insensitive
    )]
    IGL,
    #[strum(
        serialize = "TRA",
        serialize = "A",
        serialize = "alpha",
        ascii_case_insensitive
    )]
    TRA,
    #[strum(
        serialize = "TRB",
        serialize = "B",
        serialize = "beta",
        ascii_case_insensitive
    )]
    TRB,
    #[strum(
        serialize = "TRG",
        serialize = "G",
        serialize = "gamma",
        ascii_case_insensitive
    )]
    TRG,
    #[strum(
        serialize = "TRD",
        serialize = "D",
        serialize = "delta",
        ascii_case_insensitive
    )]
    TRD,
}
```