### PR TITLE
feat: add error handling to numbering and segmentation processes

### DIFF
--- a/immunum/__init__.py
+++ b/immunum/__init__.py
@@ -1,5 +1,6 @@
 from immunum._internal import _Annotator  # noqa: F401
 from dataclasses import dataclass
+from typing import Optional
 
 _CHAIN_ALIASES: dict[str, str] = {
     "igh": "IGH",
@@ -101,21 +102,22 @@ class SegmenationResult:
     ```
     """
 
-    fr1: str
-    cdr1: str
-    fr2: str
-    cdr2: str
-    fr3: str
-    cdr3: str
-    fr4: str
-    prefix: str
-    postfix: str
+    fr1: Optional[str]
+    cdr1: Optional[str]
+    fr2: Optional[str]
+    cdr2: Optional[str]
+    fr3: Optional[str]
+    cdr3: Optional[str]
+    fr4: Optional[str]
+    prefix: Optional[str]
+    postfix: Optional[str]
+    error: Optional[str]
 
-    def as_dict(self) -> dict[str, str]:
-        """Return dict mapping segment names to sequences
+    def as_dict(self) -> dict[str, Optional[str]]:
+        """Return dict mapping segment names to sequences (excludes error field)
 
         Returns:
-            dict[str, str]: dict mapping ['fr1', 'fr2', ...] to their aminoacid sequences
+            dict[str, str | None]: dict mapping ['fr1', 'fr2', ...] to their aminoacid sequences
         """
         return {
             "fr1": self.fr1,
@@ -166,10 +168,11 @@ class NumberingResult:
     ```
     """
 
-    chain: str
-    scheme: str
-    confidence: float
-    numbering: dict[str, str]
+    chain: Optional[str]
+    scheme: Optional[str]
+    confidence: Optional[float]
+    numbering: Optional[dict[str, str]]
+    error: Optional[str]
 
 
 class Annotator:
@@ -240,10 +243,8 @@ class Annotator:
 
         Returns:
             A `NumberingResult` with the detected chain, scheme, confidence score,
-            and a ``{position: residue}`` numbering dict.
-
-        Raises:
-            ValueError: If the sequence is empty or scores below ``min_confidence``.
+            and a ``{position: residue}`` numbering dict. On failure, ``error`` is
+            set and all other fields are ``None``.
         """
         return NumberingResult(**self._annotator.number(sequence))
 
@@ -255,9 +256,19 @@ class Annotator:
 
         Returns:
             A `SegmenationResult` with ``fr1``–``fr4``, ``cdr1``–``cdr3``,
-            and any unaligned ``prefix``/``postfix`` residues.
-
-        Raises:
-            ValueError: If the sequence is empty or scores below ``min_confidence``.
+            and any unaligned ``prefix``/``postfix`` residues. On failure,
+            ``error`` is set and all region fields are ``None``.
         """
-        return SegmenationResult(**self._annotator.segment(sequence))
+        raw = self._annotator.segment(sequence)
+        return SegmenationResult(
+            fr1=raw.get("fr1"),
+            cdr1=raw.get("cdr1"),
+            fr2=raw.get("fr2"),
+            cdr2=raw.get("cdr2"),
+            fr3=raw.get("fr3"),
+            cdr3=raw.get("cdr3"),
+            fr4=raw.get("fr4"),
+            prefix=raw.get("prefix"),
+            postfix=raw.get("postfix"),
+            error=raw.get("error"),
+        )

--- a/immunum/polars.py
+++ b/immunum/polars.py
@@ -65,6 +65,7 @@ def number(
                 "residues": pl.List(
                     pl.String
                 ),
+                "error": pl.String,
             }
         )
     ]
@@ -155,6 +156,7 @@ def segment(
             "cdr3": pl.String,
             "fr4": pl.String,
             "postfix": pl.String,
+            "error": pl.String,
         }
     )
     print(
@@ -236,6 +238,7 @@ def numbering_method(expr: IntoExprColumn, *, annotator: Annotator) -> pl.Expr:
         "scheme",
         "confidence",
         "numbering",
+        "error",
     }
     ```
 
@@ -299,6 +302,7 @@ def segmentation_method(expr: IntoExprColumn, *, annotator: Annotator) -> pl.Exp
             "cdr3": pl.String,
             "fr4": pl.String,
             "postfix": pl.String,
+            "error": pl.String,
         }
     )
     ```

--- a/src/io.rs
+++ b/src/io.rs
@@ -12,11 +12,31 @@ pub struct Record {
     pub sequence: String,
 }
 
-/// A numbered record: input record paired with its numbering result
+/// A numbered record: input record paired with its numbering result (or an error)
 pub struct NumberedRecord {
     pub id: String,
     pub sequence: String,
-    pub result: NumberingResult,
+    pub result: Option<NumberingResult>,
+    pub error: Option<String>,
+}
+
+impl NumberedRecord {
+    pub fn success(id: String, sequence: String, result: NumberingResult) -> Self {
+        Self {
+            id,
+            sequence,
+            result: Some(result),
+            error: None,
+        }
+    }
+    pub fn failure(id: String, sequence: String, error: String) -> Self {
+        Self {
+            id,
+            sequence,
+            result: None,
+            error: Some(error),
+        }
+    }
 }
 
 /// Output format
@@ -58,7 +78,7 @@ impl OutputFormat {
         match self {
             Self::Tsv => writeln!(
                 writer,
-                "sequence_id\tchain\tscheme\tconfidence\tposition\tresidue"
+                "sequence_id\tchain\tscheme\tconfidence\tposition\tresidue\terror"
             ),
             Self::Json => writeln!(writer, "["),
             Self::Jsonl => Ok(()),
@@ -186,7 +206,7 @@ pub fn read_fasta(reader: impl BufRead) -> Result<Vec<Record>, String> {
 pub fn write_tsv(writer: &mut impl Write, records: &[NumberedRecord]) -> io::Result<()> {
     writeln!(
         writer,
-        "sequence_id\tchain\tscheme\tconfidence\tposition\tresidue"
+        "sequence_id\tchain\tscheme\tconfidence\tposition\tresidue\terror"
     )?;
     for rec in records {
         write_tsv_record(writer, rec)?;
@@ -196,13 +216,25 @@ pub fn write_tsv(writer: &mut impl Write, records: &[NumberedRecord]) -> io::Res
 
 /// Write a single record in TSV format (without header)
 fn write_tsv_record(writer: &mut impl Write, rec: &NumberedRecord) -> io::Result<()> {
-    let aligned_seq = &rec.sequence[rec.result.query_start..=rec.result.query_end];
-    for (pos, ch) in rec.result.positions.iter().zip(aligned_seq.chars()) {
-        writeln!(
-            writer,
-            "{}\t{}\t{}\t{:.4}\t{}\t{}",
-            rec.id, rec.result.chain, rec.result.scheme, rec.result.confidence, pos, ch
-        )?;
+    match &rec.result {
+        Some(result) => {
+            let aligned_seq = &rec.sequence[result.query_start..=result.query_end];
+            for (pos, ch) in result.positions.iter().zip(aligned_seq.chars()) {
+                writeln!(
+                    writer,
+                    "{}\t{}\t{}\t{:.4}\t{}\t{}\t",
+                    rec.id, result.chain, result.scheme, result.confidence, pos, ch
+                )?;
+            }
+        }
+        None => {
+            writeln!(
+                writer,
+                "{}\t\t\t\t\t\t{}",
+                rec.id,
+                rec.error.as_deref().unwrap_or("")
+            )?;
+        }
     }
     Ok(())
 }
@@ -226,22 +258,33 @@ pub fn write_jsonl(writer: &mut impl Write, records: &[NumberedRecord]) -> io::R
 }
 
 fn record_to_json(rec: &NumberedRecord) -> serde_json::Value {
-    let aligned_seq = &rec.sequence[rec.result.query_start..=rec.result.query_end];
-    let numbering: serde_json::Map<String, serde_json::Value> = rec
-        .result
-        .positions
-        .iter()
-        .zip(aligned_seq.chars())
-        .map(|(pos, ch)| (pos.to_string(), serde_json::Value::String(ch.to_string())))
-        .collect();
-
-    serde_json::json!({
-        "sequence_id": rec.id,
-        "chain": rec.result.chain.to_string(),
-        "scheme": rec.result.scheme.to_string(),
-        "confidence": rec.result.confidence,
-        "numbering": numbering,
-    })
+    match &rec.result {
+        Some(result) => {
+            let aligned_seq = &rec.sequence[result.query_start..=result.query_end];
+            let numbering: serde_json::Map<String, serde_json::Value> = result
+                .positions
+                .iter()
+                .zip(aligned_seq.chars())
+                .map(|(pos, ch)| (pos.to_string(), serde_json::Value::String(ch.to_string())))
+                .collect();
+            serde_json::json!({
+                "sequence_id": rec.id,
+                "chain": result.chain.to_string(),
+                "scheme": result.scheme.to_string(),
+                "confidence": result.confidence,
+                "numbering": numbering,
+                "error": null,
+            })
+        }
+        None => serde_json::json!({
+            "sequence_id": rec.id,
+            "chain": null,
+            "scheme": null,
+            "confidence": null,
+            "numbering": null,
+            "error": rec.error.as_deref().unwrap_or("unknown error"),
+        }),
+    }
 }
 
 #[cfg(test)]
@@ -303,21 +346,39 @@ mod tests {
                 insertion: None,
             },
         ]);
-        let records = vec![NumberedRecord {
-            id: "s1".to_string(),
-            sequence: "EV".to_string(),
+        let records = vec![NumberedRecord::success(
+            "s1".to_string(),
+            "EV".to_string(),
             result,
-        }];
+        )];
         let mut buf = Vec::new();
         write_tsv(&mut buf, &records).unwrap();
         let output = String::from_utf8(buf).unwrap();
         let lines: Vec<&str> = output.lines().collect();
         assert_eq!(
             lines[0],
-            "sequence_id\tchain\tscheme\tconfidence\tposition\tresidue"
+            "sequence_id\tchain\tscheme\tconfidence\tposition\tresidue\terror"
         );
-        assert_eq!(lines[1], "s1\tH\tIMGT\t1.0000\t1\tE");
-        assert_eq!(lines[2], "s1\tH\tIMGT\t1.0000\t2\tV");
+        assert_eq!(lines[1], "s1\tH\tIMGT\t1.0000\t1\tE\t");
+        assert_eq!(lines[2], "s1\tH\tIMGT\t1.0000\t2\tV\t");
+    }
+
+    #[test]
+    fn test_write_tsv_error() {
+        let records = vec![NumberedRecord::failure(
+            "bad".to_string(),
+            "AAAAA".to_string(),
+            "low confidence".to_string(),
+        )];
+        let mut buf = Vec::new();
+        write_tsv(&mut buf, &records).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(
+            lines[0],
+            "sequence_id\tchain\tscheme\tconfidence\tposition\tresidue\terror"
+        );
+        assert_eq!(lines[1], "bad\t\t\t\t\t\tlow confidence");
     }
 
     #[test]
@@ -326,17 +387,34 @@ mod tests {
             number: 1,
             insertion: None,
         }]);
-        let records = vec![NumberedRecord {
-            id: "s1".to_string(),
-            sequence: "E".to_string(),
+        let records = vec![NumberedRecord::success(
+            "s1".to_string(),
+            "E".to_string(),
             result,
-        }];
+        )];
         let mut buf = Vec::new();
         write_jsonl(&mut buf, &records).unwrap();
         let output = String::from_utf8(buf).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
         assert_eq!(parsed["sequence_id"], "s1");
         assert_eq!(parsed["numbering"]["1"], "E");
+        assert!(parsed["error"].is_null());
+    }
+
+    #[test]
+    fn test_write_jsonl_error() {
+        let records = vec![NumberedRecord::failure(
+            "bad".to_string(),
+            "AAAAA".to_string(),
+            "low confidence".to_string(),
+        )];
+        let mut buf = Vec::new();
+        write_jsonl(&mut buf, &records).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(parsed["sequence_id"], "bad");
+        assert!(parsed["chain"].is_null());
+        assert_eq!(parsed["error"], "low confidence");
     }
 
     #[test]
@@ -345,17 +423,18 @@ mod tests {
             number: 1,
             insertion: None,
         }]);
-        let records = vec![NumberedRecord {
-            id: "s1".to_string(),
-            sequence: "E".to_string(),
+        let records = vec![NumberedRecord::success(
+            "s1".to_string(),
+            "E".to_string(),
             result,
-        }];
+        )];
         let mut buf = Vec::new();
         write_json(&mut buf, &records).unwrap();
         let output = String::from_utf8(buf).unwrap();
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&output).unwrap();
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0]["sequence_id"], "s1");
+        assert!(parsed[0]["error"].is_null());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,22 +69,14 @@ fn run_number(args: &NumberArgs) -> Result<(), String> {
         .write_header(&mut writer)
         .map_err(|e| format!("write error: {}", e))?;
 
-    let mut written = 0;
-    for rec in records {
-        let result = match annotator.number(&rec.sequence) {
-            Ok(result) => result,
-            Err(immunum::Error::LowConfidence { .. }) => continue,
-            Err(e) => return Err(format!("failed to number '{}': {}", rec.id, e)),
-        };
-        let numbered = NumberedRecord {
-            id: rec.id,
-            sequence: rec.sequence,
-            result,
+    for (written, rec) in records.into_iter().enumerate() {
+        let numbered = match annotator.number(&rec.sequence) {
+            Ok(result) => NumberedRecord::success(rec.id, rec.sequence, result),
+            Err(e) => NumberedRecord::failure(rec.id, rec.sequence, e.to_string()),
         };
         format
             .write_record(&mut writer, &numbered, written)
             .map_err(|e| format!("write error: {}", e))?;
-        written += 1;
     }
 
     format

--- a/src/polars.rs
+++ b/src/polars.rs
@@ -65,6 +65,7 @@ fn numbering_class_struct_output(_input_fields: &[Field]) -> PolarsResult<Field>
             "numbering".into(),
             DataType::List(Box::new(DataType::Struct(inner_fields))),
         ),
+        Field::new("error".into(), DataType::String),
     ];
     Ok(Field::new("numbering".into(), DataType::Struct(fields)))
 }
@@ -81,6 +82,7 @@ fn numbering_struct_output(_input_fields: &[Field]) -> PolarsResult<Field> {
             "residues".into(),
             DataType::List(Box::new(DataType::String)),
         ),
+        Field::new("error".into(), DataType::String),
     ];
     Ok(Field::new("numbering".into(), DataType::Struct(fields)))
 }
@@ -93,14 +95,17 @@ fn numbering_class_struct_expr(inputs: &[Series], kwargs: NumberKwargs) -> Polar
 
     // Build per-row structs inside the parallel closure so Series allocation
     // is parallelized. Series is Send+Sync in Polars, so this is safe.
-    type RowResult = Option<(String, String, f32, Series)>;
+    type RowResult = Result<(String, String, f32, Series), String>;
     let values: Vec<Option<&str>> = ca.into_iter().collect();
-    let results: Vec<RowResult> = POOL.install(|| {
+    let results: Vec<Option<RowResult>> = POOL.install(|| {
         values
             .par_iter()
             .map_with(kwargs.annotator, |ann, opt_v| {
                 let value = (*opt_v)?;
-                let result = ann.number(value).ok()?;
+                let result = match ann.number(value) {
+                    Ok(r) => r,
+                    Err(e) => return Some(Err(e.to_string())),
+                };
                 let (positions, residues): (Vec<String>, Vec<String>) = result
                     .positions
                     .iter()
@@ -114,12 +119,12 @@ fn numbering_class_struct_expr(inputs: &[Series], kwargs: NumberKwargs) -> Polar
                     StructChunked::from_series("".into(), n, [pos_series, res_series].iter())
                         .ok()?
                         .into_series();
-                Some((
+                Some(Ok((
                     result.chain.to_string(),
                     result.scheme.to_string(),
                     result.confidence,
                     row_struct,
-                ))
+                )))
             })
             .collect()
     });
@@ -128,6 +133,7 @@ fn numbering_class_struct_expr(inputs: &[Series], kwargs: NumberKwargs) -> Polar
     let mut scheme_vec: Vec<Option<String>> = Vec::with_capacity(len);
     let mut confidence_vec: Vec<Option<f32>> = Vec::with_capacity(len);
     let mut row_structs: Vec<Option<Series>> = Vec::with_capacity(len);
+    let mut error_vec: Vec<Option<String>> = Vec::with_capacity(len);
 
     for row in results {
         match row {
@@ -136,12 +142,21 @@ fn numbering_class_struct_expr(inputs: &[Series], kwargs: NumberKwargs) -> Polar
                 scheme_vec.push(None);
                 confidence_vec.push(None);
                 row_structs.push(None);
+                error_vec.push(None);
             }
-            Some((chain, scheme, confidence, row_struct)) => {
+            Some(Err(e)) => {
+                chain_vec.push(None);
+                scheme_vec.push(None);
+                confidence_vec.push(None);
+                row_structs.push(None);
+                error_vec.push(Some(e));
+            }
+            Some(Ok((chain, scheme, confidence, row_struct))) => {
                 chain_vec.push(Some(chain));
                 scheme_vec.push(Some(scheme));
                 confidence_vec.push(Some(confidence));
                 row_structs.push(Some(row_struct));
+                error_vec.push(None);
             }
         }
     }
@@ -158,12 +173,14 @@ fn numbering_class_struct_expr(inputs: &[Series], kwargs: NumberKwargs) -> Polar
     let scheme_series = Series::new("scheme".into(), scheme_vec);
     let confidence_series = Series::new("confidence".into(), confidence_vec);
     let numbering_series = numbering_builder.finish().into_series();
+    let error_series = Series::new("error".into(), error_vec);
 
     let fields = [
         chain_series,
         scheme_series,
         confidence_series,
         numbering_series,
+        error_series,
     ];
     StructChunked::from_series(name, len, fields.iter()).map(|ca| ca.into_series())
 }
@@ -182,26 +199,29 @@ fn numbering_struct_expr(inputs: &[Series], kwargs: NumberFuncKwargs) -> PolarsR
         Err(e) => polars_bail!(InvalidOperation: "{}", e),
     };
 
-    type ResultType = Vec<Option<(String, String, Series, Series)>>;
+    type ResultType = Vec<Option<Result<(String, String, Series, Series), String>>>;
     let values: Vec<Option<&str>> = ca.into_iter().collect();
     let results: ResultType = POOL.install(|| {
         values
             .par_iter()
             .map_with(annotator, |ann, opt_v| {
                 let value = (*opt_v)?;
-                let result = ann.number(value).ok()?;
+                let result = match ann.number(value) {
+                    Ok(r) => r,
+                    Err(e) => return Some(Err(e.to_string())),
+                };
                 let (positions, residues): (Vec<String>, Vec<String>) = result
                     .positions
                     .iter()
                     .zip(value.chars())
                     .map(|(pos, ch)| (pos.to_string(), ch.to_string()))
                     .unzip();
-                Some((
+                Some(Ok((
                     result.chain.to_string(),
                     result.scheme.to_string(),
                     Series::new("".into(), positions),
                     Series::new("".into(), residues),
-                ))
+                )))
             })
             .collect()
     });
@@ -210,6 +230,7 @@ fn numbering_struct_expr(inputs: &[Series], kwargs: NumberFuncKwargs) -> PolarsR
     let mut scheme_builder = StringChunkedBuilder::new("scheme".into(), len);
     let mut positions_builder = ListStringChunkedBuilder::new("positions".into(), len, len);
     let mut residues_builder = ListStringChunkedBuilder::new("residues".into(), len, len);
+    let mut error_builder = StringChunkedBuilder::new("error".into(), len);
 
     for row in results {
         match row {
@@ -218,12 +239,21 @@ fn numbering_struct_expr(inputs: &[Series], kwargs: NumberFuncKwargs) -> PolarsR
                 scheme_builder.append_null();
                 positions_builder.append_null();
                 residues_builder.append_null();
+                error_builder.append_null();
             }
-            Some((chain, scheme, positions, residues)) => {
+            Some(Err(e)) => {
+                chain_builder.append_null();
+                scheme_builder.append_null();
+                positions_builder.append_null();
+                residues_builder.append_null();
+                error_builder.append_value(&e);
+            }
+            Some(Ok((chain, scheme, positions, residues))) => {
                 chain_builder.append_value(&chain);
                 scheme_builder.append_value(&scheme);
                 positions_builder.append_series(&positions)?;
                 residues_builder.append_series(&residues)?;
+                error_builder.append_null();
             }
         }
     }
@@ -233,6 +263,7 @@ fn numbering_struct_expr(inputs: &[Series], kwargs: NumberFuncKwargs) -> PolarsR
         scheme_builder.finish().into_series(),
         positions_builder.finish().into_series(),
         residues_builder.finish().into_series(),
+        error_builder.finish().into_series(),
     ];
     StructChunked::from_series(name, len, fields.iter()).map(|ca| ca.into_series())
 }
@@ -250,6 +281,7 @@ fn segmentation_struct_output(_input_fields: &[Field]) -> PolarsResult<Field> {
         Field::new("cdr3".into(), DataType::String),
         Field::new("fr4".into(), DataType::String),
         Field::new("postfix".into(), DataType::String),
+        Field::new("error".into(), DataType::String),
     ];
     Ok(Field::new("segmentation".into(), DataType::Struct(fields)))
 }
@@ -260,17 +292,20 @@ fn segmentation_class_struct_expr(inputs: &[Series], kwargs: NumberKwargs) -> Po
     let len = ca.len();
     let name = ca.name().clone();
 
-    type SegResult = Option<[String; 9]>;
+    type SegResult = Option<Result<[String; 9], String>>;
     let values: Vec<Option<&str>> = ca.into_iter().collect();
     let results: Vec<SegResult> = POOL.install(|| {
         values
             .par_iter()
             .map_with(kwargs.annotator, |ann, opt_v| {
                 let value = (*opt_v)?;
-                let result = ann.number(value).ok()?;
+                let result = match ann.number(value) {
+                    Ok(r) => r,
+                    Err(e) => return Some(Err(e.to_string())),
+                };
                 let s = segment(&result.positions, value, result.scheme);
                 let get = |k: &str| s.get(k).map(|v| v.as_str()).unwrap_or("").to_string();
-                Some([
+                Some(Ok([
                     get("prefix"),
                     get("fr1"),
                     get("cdr1"),
@@ -280,7 +315,7 @@ fn segmentation_class_struct_expr(inputs: &[Series], kwargs: NumberKwargs) -> Po
                     get("cdr3"),
                     get("fr4"),
                     get("postfix"),
-                ])
+                ]))
             })
             .collect()
     });
@@ -294,6 +329,7 @@ fn segmentation_class_struct_expr(inputs: &[Series], kwargs: NumberKwargs) -> Po
     let mut cdr3_b = StringChunkedBuilder::new("cdr3".into(), len);
     let mut fr4_b = StringChunkedBuilder::new("fr4".into(), len);
     let mut postfix_b = StringChunkedBuilder::new("postfix".into(), len);
+    let mut error_b = StringChunkedBuilder::new("error".into(), len);
 
     for row in results {
         match row {
@@ -307,8 +343,21 @@ fn segmentation_class_struct_expr(inputs: &[Series], kwargs: NumberKwargs) -> Po
                 cdr3_b.append_null();
                 fr4_b.append_null();
                 postfix_b.append_null();
+                error_b.append_null();
             }
-            Some([prefix, fr1, cdr1, fr2, cdr2, fr3, cdr3, fr4, postfix]) => {
+            Some(Err(e)) => {
+                prefix_b.append_null();
+                fr1_b.append_null();
+                cdr1_b.append_null();
+                fr2_b.append_null();
+                cdr2_b.append_null();
+                fr3_b.append_null();
+                cdr3_b.append_null();
+                fr4_b.append_null();
+                postfix_b.append_null();
+                error_b.append_value(&e);
+            }
+            Some(Ok([prefix, fr1, cdr1, fr2, cdr2, fr3, cdr3, fr4, postfix])) => {
                 prefix_b.append_value(&prefix);
                 fr1_b.append_value(&fr1);
                 cdr1_b.append_value(&cdr1);
@@ -318,6 +367,7 @@ fn segmentation_class_struct_expr(inputs: &[Series], kwargs: NumberKwargs) -> Po
                 cdr3_b.append_value(&cdr3);
                 fr4_b.append_value(&fr4);
                 postfix_b.append_value(&postfix);
+                error_b.append_null();
             }
         }
     }
@@ -332,6 +382,7 @@ fn segmentation_class_struct_expr(inputs: &[Series], kwargs: NumberKwargs) -> Po
         cdr3_b.finish().into_series(),
         fr4_b.finish().into_series(),
         postfix_b.finish().into_series(),
+        error_b.finish().into_series(),
     ];
     StructChunked::from_series(name, len, fields.iter()).map(|ca| ca.into_series())
 }
@@ -350,17 +401,20 @@ fn segmentation_struct_expr(inputs: &[Series], kwargs: NumberFuncKwargs) -> Pola
         Err(e) => polars_bail!(InvalidOperation: "{}", e),
     };
 
-    type SegResult = Option<[String; 9]>;
+    type SegResult = Option<Result<[String; 9], String>>;
     let values: Vec<Option<&str>> = ca.into_iter().collect();
     let results: Vec<SegResult> = POOL.install(|| {
         values
             .par_iter()
             .map_with(annotator, |ann, opt_v| {
                 let value = (*opt_v)?;
-                let result = ann.number(value).ok()?;
+                let result = match ann.number(value) {
+                    Ok(r) => r,
+                    Err(e) => return Some(Err(e.to_string())),
+                };
                 let s = segment(&result.positions, value, result.scheme);
                 let get = |k: &str| s.get(k).map(|v| v.as_str()).unwrap_or("").to_string();
-                Some([
+                Some(Ok([
                     get("prefix"),
                     get("fr1"),
                     get("cdr1"),
@@ -370,7 +424,7 @@ fn segmentation_struct_expr(inputs: &[Series], kwargs: NumberFuncKwargs) -> Pola
                     get("cdr3"),
                     get("fr4"),
                     get("postfix"),
-                ])
+                ]))
             })
             .collect()
     });
@@ -384,6 +438,7 @@ fn segmentation_struct_expr(inputs: &[Series], kwargs: NumberFuncKwargs) -> Pola
     let mut cdr3_b = StringChunkedBuilder::new("cdr3".into(), len);
     let mut fr4_b = StringChunkedBuilder::new("fr4".into(), len);
     let mut postfix_b = StringChunkedBuilder::new("postfix".into(), len);
+    let mut error_b = StringChunkedBuilder::new("error".into(), len);
 
     for row in results {
         match row {
@@ -397,8 +452,21 @@ fn segmentation_struct_expr(inputs: &[Series], kwargs: NumberFuncKwargs) -> Pola
                 cdr3_b.append_null();
                 fr4_b.append_null();
                 postfix_b.append_null();
+                error_b.append_null();
             }
-            Some([prefix, fr1, cdr1, fr2, cdr2, fr3, cdr3, fr4, postfix]) => {
+            Some(Err(e)) => {
+                prefix_b.append_null();
+                fr1_b.append_null();
+                cdr1_b.append_null();
+                fr2_b.append_null();
+                cdr2_b.append_null();
+                fr3_b.append_null();
+                cdr3_b.append_null();
+                fr4_b.append_null();
+                postfix_b.append_null();
+                error_b.append_value(&e);
+            }
+            Some(Ok([prefix, fr1, cdr1, fr2, cdr2, fr3, cdr3, fr4, postfix])) => {
                 prefix_b.append_value(&prefix);
                 fr1_b.append_value(&fr1);
                 cdr1_b.append_value(&cdr1);
@@ -408,6 +476,7 @@ fn segmentation_struct_expr(inputs: &[Series], kwargs: NumberFuncKwargs) -> Pola
                 cdr3_b.append_value(&cdr3);
                 fr4_b.append_value(&fr4);
                 postfix_b.append_value(&postfix);
+                error_b.append_null();
             }
         }
     }
@@ -422,6 +491,7 @@ fn segmentation_struct_expr(inputs: &[Series], kwargs: NumberFuncKwargs) -> Pola
         cdr3_b.finish().into_series(),
         fr4_b.finish().into_series(),
         postfix_b.finish().into_series(),
+        error_b.finish().into_series(),
     ];
     StructChunked::from_series(name, len, fields.iter()).map(|ca| ca.into_series())
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -45,42 +45,46 @@ impl Annotator {
 
     #[pyo3(signature = (sequence), name = "number")]
     pub fn _number<'py>(&self, py: Python<'py>, sequence: &str) -> PyResult<Bound<'py, PyDict>> {
-        let result = self.number(sequence).map_err(|_| {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                "Invalid sequence: {}",
-                sequence
-            ))
-        })?;
-
-        let numbering = PyDict::new(py);
-        let aligned_seq = &sequence[result.query_start..=result.query_end];
-        for (pos, ch) in result.positions.iter().zip(aligned_seq.chars()) {
-            numbering.set_item(pos.to_string(), ch.to_string())?;
-        }
-
         let dict = PyDict::new(py);
-        dict.set_item("chain", result.chain.to_string())?;
-        dict.set_item("scheme", result.scheme.to_string())?;
-        dict.set_item("confidence", result.confidence)?;
-        dict.set_item("numbering", numbering)?;
+        match self.number(sequence) {
+            Ok(result) => {
+                let numbering = PyDict::new(py);
+                let aligned_seq = &sequence[result.query_start..=result.query_end];
+                for (pos, ch) in result.positions.iter().zip(aligned_seq.chars()) {
+                    numbering.set_item(pos.to_string(), ch.to_string())?;
+                }
+                dict.set_item("chain", result.chain.to_string())?;
+                dict.set_item("scheme", result.scheme.to_string())?;
+                dict.set_item("confidence", result.confidence)?;
+                dict.set_item("numbering", numbering)?;
+                dict.set_item("error", py.None())?;
+            }
+            Err(e) => {
+                dict.set_item("chain", py.None())?;
+                dict.set_item("scheme", py.None())?;
+                dict.set_item("confidence", py.None())?;
+                dict.set_item("numbering", py.None())?;
+                dict.set_item("error", e.to_string())?;
+            }
+        }
         Ok(dict)
     }
 
     #[pyo3(signature = (sequence), name = "segment")]
     pub fn _segment<'py>(&self, py: Python<'py>, sequence: &str) -> PyResult<Bound<'py, PyDict>> {
-        let result = self.number(sequence).map_err(|_| {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                "Invalid sequence: {}",
-                sequence
-            ))
-        })?;
-
-        let aligned_seq = &sequence[result.query_start..=result.query_end];
-        let segments = segment(&result.positions, aligned_seq, result.scheme);
-
         let dict = PyDict::new(py);
-        for (region, seq) in segments {
-            dict.set_item(region, seq)?;
+        match self.number(sequence) {
+            Ok(result) => {
+                let aligned_seq = &sequence[result.query_start..=result.query_end];
+                let segments = segment(&result.positions, aligned_seq, result.scheme);
+                for (region, seq) in segments {
+                    dict.set_item(region, seq)?;
+                }
+                dict.set_item("error", py.None())?;
+            }
+            Err(e) => {
+                dict.set_item("error", e.to_string())?;
+            }
         }
         Ok(dict)
     }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -11,31 +11,35 @@ const TS_TYPES: &str = r#"
 /** Numbered residues keyed by IMGT/Kabat position string (e.g. `"112A"`). */
 export type Numbering = Record<string, string>;
 
-/** Result returned by {@link Annotator.number}. */
+/** Result returned by {@link Annotator.number}. On failure, chain/scheme/confidence/numbering are null and error contains the reason. */
 export interface NumberingResult {
-    /** Detected chain type: `"H"`, `"K"`, `"L"`, `"A"`, `"B"`, `"G"`, or `"D"`. */
-    chain: string;
-    /** Numbering scheme used: `"imgt"` or `"kabat"`. */
-    scheme: string;
-    /** Alignment confidence score between 0 and 1. */
-    confidence: number;
-    /** Position-to-residue mapping for the aligned region. */
-    numbering: Numbering;
+    /** Detected chain type: `"H"`, `"K"`, `"L"`, `"A"`, `"B"`, `"G"`, or `"D"`. Null on failure. */
+    chain: string | null;
+    /** Numbering scheme used: `"imgt"` or `"kabat"`. Null on failure. */
+    scheme: string | null;
+    /** Alignment confidence score between 0 and 1. Null on failure. */
+    confidence: number | null;
+    /** Position-to-residue mapping for the aligned region. Null on failure. */
+    numbering: Numbering | null;
+    /** Error message if numbering failed, null on success. */
+    error: string | null;
 }
 
-/** FR/CDR segments returned by {@link Annotator.segment}. */
+/** FR/CDR segments returned by {@link Annotator.segment}. On failure, all region fields are absent and error contains the reason. */
 export interface SegmentationResult {
-    fr1: string;
-    cdr1: string;
-    fr2: string;
-    cdr2: string;
-    fr3: string;
-    cdr3: string;
-    fr4: string;
+    fr1?: string;
+    cdr1?: string;
+    fr2?: string;
+    cdr2?: string;
+    fr3?: string;
+    cdr3?: string;
+    fr4?: string;
     /** Residues before FR1 (non-canonical N-terminal extension). */
-    prefix: string;
+    prefix?: string;
     /** Residues after FR4 (non-canonical C-terminal extension). */
-    postfix: string;
+    postfix?: string;
+    /** Error message if segmentation failed, null on success. */
+    error: string | null;
 }
 
 /**
@@ -69,6 +73,7 @@ export class Annotator {
     constructor(chains: string[], scheme: string, min_confidence?: number | null);
     number(sequence: string): NumberingResult;
     segment(sequence: string): SegmentationResult;
+
 }
 "#;
 
@@ -94,44 +99,55 @@ impl Annotator {
     }
 
     #[wasm_bindgen(js_name = "number", skip_typescript)]
-    pub fn wasm_number(&self, sequence: &str) -> Result<JsValue, JsValue> {
-        let result = self
-            .number(sequence)
-            .map_err(|e| JsValue::from_str(&e.to_string()))?;
-
-        let aligned_seq = &sequence[result.query_start..=result.query_end];
-        let numbering = Object::new();
-        for (pos, ch) in result.positions.iter().zip(aligned_seq.chars()) {
-            Reflect::set(
-                &numbering,
-                &JsValue::from_str(&pos.to_string()),
-                &JsValue::from_str(&ch.to_string()),
-            )
-            .unwrap();
-        }
-
+    pub fn wasm_number(&self, sequence: &str) -> JsValue {
         let dict = Object::new();
-        Reflect::set(&dict, &"chain".into(), &result.chain.to_string().into()).unwrap();
-        Reflect::set(&dict, &"scheme".into(), &result.scheme.to_string().into()).unwrap();
-        Reflect::set(&dict, &"confidence".into(), &result.confidence.into()).unwrap();
-        Reflect::set(&dict, &"numbering".into(), &numbering.into()).unwrap();
-        Ok(dict.into())
+        match self.number(sequence) {
+            Ok(result) => {
+                let aligned_seq = &sequence[result.query_start..=result.query_end];
+                let numbering = Object::new();
+                for (pos, ch) in result.positions.iter().zip(aligned_seq.chars()) {
+                    Reflect::set(
+                        &numbering,
+                        &JsValue::from_str(&pos.to_string()),
+                        &JsValue::from_str(&ch.to_string()),
+                    )
+                    .unwrap();
+                }
+                Reflect::set(&dict, &"chain".into(), &result.chain.to_string().into()).unwrap();
+                Reflect::set(&dict, &"scheme".into(), &result.scheme.to_string().into()).unwrap();
+                Reflect::set(&dict, &"confidence".into(), &result.confidence.into()).unwrap();
+                Reflect::set(&dict, &"numbering".into(), &numbering.into()).unwrap();
+                Reflect::set(&dict, &"error".into(), &JsValue::NULL).unwrap();
+            }
+            Err(e) => {
+                Reflect::set(&dict, &"chain".into(), &JsValue::NULL).unwrap();
+                Reflect::set(&dict, &"scheme".into(), &JsValue::NULL).unwrap();
+                Reflect::set(&dict, &"confidence".into(), &JsValue::NULL).unwrap();
+                Reflect::set(&dict, &"numbering".into(), &JsValue::NULL).unwrap();
+                Reflect::set(&dict, &"error".into(), &JsValue::from_str(&e.to_string())).unwrap();
+            }
+        }
+        dict.into()
     }
 
     #[wasm_bindgen(js_name = "segment", skip_typescript)]
-    pub fn wasm_segment(&self, sequence: &str) -> Result<JsValue, JsValue> {
-        let result = self
-            .number(sequence)
-            .map_err(|e| JsValue::from_str(&e.to_string()))?;
-
-        let aligned_seq = &sequence[result.query_start..=result.query_end];
-        let segments = segment(&result.positions, aligned_seq, result.scheme);
-
+    pub fn wasm_segment(&self, sequence: &str) -> JsValue {
         let dict = Object::new();
-        for (region, seq) in &segments {
-            Reflect::set(&dict, &JsValue::from_str(region), &JsValue::from_str(seq)).unwrap();
+        match self.number(sequence) {
+            Ok(result) => {
+                let aligned_seq = &sequence[result.query_start..=result.query_end];
+                let segments = segment(&result.positions, aligned_seq, result.scheme);
+                for (region, seq) in &segments {
+                    Reflect::set(&dict, &JsValue::from_str(region), &JsValue::from_str(seq))
+                        .unwrap();
+                }
+                Reflect::set(&dict, &"error".into(), &JsValue::NULL).unwrap();
+            }
+            Err(e) => {
+                Reflect::set(&dict, &"error".into(), &JsValue::from_str(&e.to_string())).unwrap();
+            }
         }
-        Ok(dict.into())
+        dict.into()
     }
 }
 
@@ -152,7 +168,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = ann.wasm_number(IGH_SEQ).unwrap();
+        let result = ann.wasm_number(IGH_SEQ);
         let chain = Reflect::get(&result, &"chain".into()).unwrap();
         assert_eq!(chain.as_string().unwrap(), "H");
         let confidence = Reflect::get(&result, &"confidence".into()).unwrap();
@@ -168,7 +184,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = ann.wasm_segment(IGH_SEQ).unwrap();
+        let result = ann.wasm_segment(IGH_SEQ);
         let fr1 = Reflect::get(&result, &"fr1".into()).unwrap();
         assert!(!fr1.as_string().unwrap().is_empty());
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -17,7 +17,7 @@ fn raw_sequence_argument() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "sequence_id\tchain\tscheme\tconfidence\tposition\tresidue",
+            "sequence_id\tchain\tscheme\tconfidence\tposition\tresidue\terror",
         ));
 }
 
@@ -155,7 +155,7 @@ fn output_to_file() {
         .stdout(predicate::str::is_empty());
 
     let contents = fs::read_to_string(&out_path).unwrap();
-    assert!(contents.contains("sequence_id\tchain\tscheme\tconfidence\tposition\tresidue"));
+    assert!(contents.contains("sequence_id\tchain\tscheme\tconfidence\tposition\tresidue\terror"));
 }
 
 // --- TSV piping via stdin ---
@@ -168,6 +168,98 @@ fn stdin_multiple_raw_sequences() {
         .assert()
         .success()
         .stdout(predicate::str::contains("seq_1").and(predicate::str::contains("seq_2")));
+}
+
+// --- Error field in output ---
+
+#[test]
+fn invalid_sequence_emits_error_record_jsonl() {
+    // A garbage sequence should appear as an error record, not abort the batch
+    let output = immunum()
+        .args(["number", "-f", "jsonl"])
+        .write_stdin("AAAAAAAAAA\n")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid jsonl");
+    assert!(
+        parsed["error"].is_string(),
+        "error field should be a string"
+    );
+    assert!(parsed["chain"].is_null(), "chain should be null on error");
+    assert!(
+        parsed["numbering"].is_null(),
+        "numbering should be null on error"
+    );
+}
+
+#[test]
+fn valid_sequence_has_null_error_jsonl() {
+    let output = immunum()
+        .args([
+            "number",
+            "-f",
+            "jsonl",
+            "EVQLVESGGGLVKPGGSLKLSCAASGFTFSSYAMS",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid jsonl");
+    assert!(parsed["error"].is_null(), "error should be null on success");
+    assert!(
+        parsed["chain"].is_string(),
+        "chain should be set on success"
+    );
+}
+
+#[test]
+fn mixed_batch_always_emits_one_record_per_input() {
+    // Two sequences: one valid IGH, one garbage
+    let input = "EVQLVESGGGLVKPGGSLKLSCAASGFTFSSYAMS\nAAAAAAAAAAAAAAAAA\n";
+    let output = immunum()
+        .args(["number", "-f", "jsonl"])
+        .write_stdin(input)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(lines.len(), 2, "one output per input");
+
+    let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    let second: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+    assert!(first["error"].is_null());
+    assert!(second["error"].is_string());
+}
+
+#[test]
+fn error_record_appears_in_tsv() {
+    let output = immunum()
+        .args(["number", "-f", "tsv"])
+        .write_stdin("AAAAAAAAAA\n")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(lines.len(), 2); // header + one error row
+    assert!(
+        lines[1].contains("seq_1"),
+        "error row should have sequence id"
+    );
+    // last column (error) should be non-empty
+    let cols: Vec<&str> = lines[1].split('\t').collect();
+    assert!(
+        !cols.last().unwrap().is_empty(),
+        "error column should be non-empty"
+    );
 }
 
 // --- Error cases ---

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -97,6 +97,26 @@ class TestPolarsNumber:
         assert "chain" in result.columns
         assert "positions" in result.columns
         assert "residues" in result.columns
+        assert "error" in result.columns
+
+    def test_number_error_field_null_on_success(self):
+        df = polars.DataFrame({"sequence": [IGH_SEQ]})
+        result = df.select(
+            imp.number(polars.col("sequence"), chains=["IGH"], scheme="IMGT").alias(
+                "numbered"
+            )
+        ).unnest("numbered")
+        assert result["error"][0] is None
+
+    def test_number_error_field_set_on_failure(self):
+        df = polars.DataFrame({"sequence": ["AAAAAAAAAAAAAAAA"]})
+        result = df.select(
+            imp.number(polars.col("sequence"), chains=["IGH"], scheme="IMGT").alias(
+                "numbered"
+            )
+        ).unnest("numbered")
+        assert result["error"][0] is not None
+        assert result["chain"][0] is None
 
     def test_number_multiple_sequences(self):
         df = polars.DataFrame({"sequence": [IGH_SEQ, SEQ]})
@@ -150,17 +170,30 @@ class TestPolarsSegment:
             )
         ).unnest("segmented")
         expected_fields = {
-            "fr1",
-            "fr2",
-            "fr3",
-            "fr4",
-            "cdr1",
-            "cdr2",
-            "cdr3",
-            "prefix",
-            "postfix",
+            "fr1", "fr2", "fr3", "fr4",
+            "cdr1", "cdr2", "cdr3",
+            "prefix", "postfix", "error",
         }
         assert expected_fields.issubset(set(result.columns))
+
+    def test_segment_error_field_null_on_success(self):
+        df = polars.DataFrame({"sequence": [IGH_SEQ]})
+        result = df.select(
+            imp.segment(polars.col("sequence"), chains=["IGH"], scheme="IMGT").alias(
+                "segmented"
+            )
+        ).unnest("segmented")
+        assert result["error"][0] is None
+
+    def test_segment_error_field_set_on_failure(self):
+        df = polars.DataFrame({"sequence": ["AAAAAAAAAAAAAAAA"]})
+        result = df.select(
+            imp.segment(polars.col("sequence"), chains=["IGH"], scheme="IMGT").alias(
+                "segmented"
+            )
+        ).unnest("segmented")
+        assert result["error"][0] is not None
+        assert result["fr1"][0] is None
 
     def test_segment_multiple_sequences(self):
         df = polars.DataFrame({"sequence": [IGH_SEQ, SEQ]})
@@ -227,3 +260,4 @@ class TestPolarsNumberingMethod:
         assert "scheme" in result.columns
         assert "confidence" in result.columns
         assert "numbering" in result.columns
+        assert "error" in result.columns

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -103,16 +103,24 @@ class TestNumbering:
         result = annotator.number(IGH_SEQ)
         assert result.chain == "H"
         assert result.scheme == "IMGT"
+        assert result.error is None
 
     def test_number_with_single_chain(self):
         annotator = immunum.Annotator(["IGH"], "IMGT")
         result = annotator.number(IGH_SEQ)
         assert result.chain == "H"
 
-    def test_empty_sequence_raises(self):
+    def test_empty_sequence_returns_error(self):
         annotator = immunum.Annotator(ALL_CHAINS, "IMGT")
-        with pytest.raises(ValueError):
-            annotator.number("")
+        result = annotator.number("")
+        assert result.error is not None
+        assert result.chain is None
+
+    def test_invalid_sequence_returns_error(self):
+        annotator = immunum.Annotator(ALL_CHAINS, "IMGT")
+        result = annotator.number("AAAAAAAAAAAAAAAA")
+        assert result.error is not None
+        assert result.chain is None
 
     def test_confidence_is_float(self, annotator_and_seq):
         annotator, seq = annotator_and_seq
@@ -125,6 +133,13 @@ class TestNumbering:
         assert set(result.as_dict()) == {f"cdr{i}" for i in (1, 2, 3)} | {
             f"fr{i}" for i in (1, 2, 3, 4)
         } | {"prefix", "postfix"}
+        assert result.error is None
+
+    def test_segmentation_invalid_sequence_returns_error(self):
+        annotator = immunum.Annotator(ALL_CHAINS, "IMGT")
+        result = annotator.segment("AAAAAAAAAAAAAAAA")
+        assert result.error is not None
+        assert result.fr1 is None
 
 
 class TestNormalization:

--- a/tests/test_wasm.mjs
+++ b/tests/test_wasm.mjs
@@ -79,9 +79,26 @@ describe("number()", () => {
     }
   });
 
-  it("throws on empty sequence", () => {
+  it("returns error field on empty sequence (does not throw)", () => {
     const annotator = new Annotator(ALL_CHAINS, "imgt");
-    assert.throws(() => annotator.number(""));
+    const result = annotator.number("");
+    assert.equal(result.chain, null);
+    assert.equal(result.numbering, null);
+    assert.equal(typeof result.error, "string");
+  });
+
+  it("returns error field on invalid sequence (does not throw)", () => {
+    const annotator = new Annotator(ALL_CHAINS, "imgt");
+    const result = annotator.number("AAAAAAAAAAAAAAAA");
+    assert.equal(result.chain, null);
+    assert.equal(result.numbering, null);
+    assert.equal(typeof result.error, "string");
+  });
+
+  it("returns null error on success", () => {
+    const annotator = new Annotator(["H"], "imgt");
+    const result = annotator.number(IGH_SEQ);
+    assert.equal(result.error, null);
   });
 
   it("detects kappa or lambda for IGL sequence", () => {
@@ -118,5 +135,18 @@ describe("segment()", () => {
     const annotator = new Annotator(["TRB"], "IMGT");
     const result = annotator.segment(TRB_SEQ);
     assert.ok(result.cdr3.length > 0);
+  });
+
+  it("returns null error on success", () => {
+    const annotator = new Annotator(["H"], "IMGT");
+    const result = annotator.segment(IGH_SEQ);
+    assert.equal(result.error, null);
+  });
+
+  it("returns error field on invalid sequence (does not throw)", () => {
+    const annotator = new Annotator(ALL_CHAINS, "IMGT");
+    const result = annotator.segment("AAAAAAAAAAAAAAAA");
+    assert.equal(typeof result.error, "string");
+    assert.equal(result.fr1, undefined);
   });
 });


### PR DESCRIPTION
- Introduced an `error` field in the output of the `number` and `segment` functions to capture error messages when processing sequences.
- Updated the `NumberedRecord` struct in Rust to include an optional `error` field.
- Modified the Python and WASM interfaces to return error messages instead of raising exceptions for invalid sequences.
- Enhanced Polars integration to include error handling in DataFrame outputs.
- Added tests to verify that error fields are correctly populated for invalid sequences and that valid sequences return null for the error field.